### PR TITLE
Fix exporting transition components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,10 @@ if (typeof window !== 'undefined' && window.Vue) {
 }
 
 export default {
-  install,
+  install
+}
+
+export {
   FadeTransition,
   ZoomCenterTransition,
   ZoomXTransition,


### PR DESCRIPTION
Importing single transition component was not working properly. 
Ex. import { FadeTransition } from 'vue2-transitions' 